### PR TITLE
Removed unused #include <sys/sysmacros.h> and unused variable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ update.log
 *~
 #*#
 .#*
+.vscode
 norminette

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,6 @@
 #include "my.h"
 #include "global2.h"
 #include "stacktrace.h"
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdlib.h>

--- a/src/scan.c
+++ b/src/scan.c
@@ -10,7 +10,6 @@
 #include "structs.h"
 #include "functions.h"
 #include "stacktrace.h"
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>

--- a/src/scan_file.c
+++ b/src/scan_file.c
@@ -7,7 +7,6 @@
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -903,7 +902,6 @@ void	scan_entire_file(char *file, int *mistakes, char *path, char const **words,
 	int	declaring_var = 0;
 	char	*ptr = file;
 	int	l_o = 0;
-	int	if_depth;
 	int	fine = 0;
 	int	parenthesis = 0;
 	int	indentBuffer = 0;


### PR DESCRIPTION
Works with macOS like a charm now.
Tested on macOS Sierra 10.12.6 and Ubuntu 16.04 LTS.